### PR TITLE
Change API: return a function that stops collection when called 🥁

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First install it:
 npm install --save collect-fps
 ```
 
-And simply call it with a callback:
+Calling it will initialize the collection and return a function. When invoked, that function will stop the collection and return the frame per seconds value (a float number).
 
 ```javascript
 import collectFPS from 'collect-fps'

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ If `requestAnimationFrame` is not available in your runtime, it will throw an er
 
 ## License
 
-[MIT](License)
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -18,19 +18,16 @@ And simply call it with a callback:
 ```javascript
 import collectFPS from 'collect-fps'
 
-collectFPS((error, fps) => {
+const endCollection = collectFPS()
+
+setTimeout(() => {
+  const fps = endCollection()
   console.log(fps)
-})
+}, 1000)
 ```
 
-By default, the library will collect 10 frames to calculate the current FPS, it is also possible to specify a custom number of frames by adding an extra argument:
+If `requestAnimationFrame` is not available in your runtime, it will throw an error when invoked
 
-```javascript
-import collectFPS from 'collect-fps'
+## License
 
-const sampleSize = 100
-
-collectFPS(sampleSize, (error, fps) => {
-  console.log(fps)
-})
-```
+[MIT](License)

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,23 +1,27 @@
 import collectFPS from '.'
 
 describe('collect-fps', function () {
-  it('should work with custom frames', function (done) {
-    collectFPS(100, (error, fps) => {
-      if (error) { return done.fail(error) }
+  it('should collect until it’s ended', function (done) {
+    const endFPSCollection = collectFPS()
+
+    setTimeout(() => {
+      const fps = endFPSCollection()
 
       expect(fps).toBeGreaterThan(0)
       expect(fps).toBeLessThan(120)
       done()
-    })
+    }, 100)
   })
 
-  it('should work with just a callback', function (done) {
-    collectFPS((error, fps) => {
-      if (error) { return done.fail(error) }
+  describe('when window.requestAnimationFrame is not available', () => {
+    it('should fail', () => {
+      const window = {}
 
-      expect(fps).toBeGreaterThan(0)
-      expect(fps).toBeLessThan(120)
-      done()
+      try {
+        collectFPS(window)
+      } catch (e) {
+        expect(e.message).toBe('requestAnimationFrame is not available')
+      }
     })
   })
 })


### PR DESCRIPTION
New API:

```javascript
import collectFPS from 'collect-fps'

const endCollection = collectFPS()

setTimeout(() => {
  const fps = endCollection()
}, 1000)
```

In an environment where `requestAnimationFrame` is not supported, it will synchronously throw the error "requestAnimationFrame is not available"